### PR TITLE
Add everyone's favorite Ruby function, Array.first

### DIFF
--- a/proto.js
+++ b/proto.js
@@ -47,6 +47,15 @@ load = function load() {
 			},
 			configurable: true
 		},
+		first: {
+			get: function() {
+				return this[0]
+			},
+			set: function(val) {
+				this[0] = val
+			},
+			configurable: true
+		},
 		last: {
 			get: function() {
 				return this[this.length - 1]


### PR DESCRIPTION
It is impossible to describe how much I miss `["hello", ", ", "world"].first` when I'm not programming in Ruby.

In Ruby, it's only a getter, I'm not sure how I feel about it being a setter.

[Rails defines second through fifth](https://github.com/rails/rails/blob/c4510b2589182d766b29eb57c3969fdd726565a8/activesupport/lib/active_support/core_ext/array/access.rb#L55), but I don't think those are as necessary.